### PR TITLE
Retrofit Caching Enabled

### DIFF
--- a/app/src/main/java/com/example/simplefastnews/MainActivity.kt
+++ b/app/src/main/java/com/example/simplefastnews/MainActivity.kt
@@ -23,6 +23,8 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.*
+import okhttp3.Cache
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -105,7 +107,7 @@ class MainActivity : AppCompatActivity(), SwipeRefreshLayout.OnRefreshListener {
     //Setup the Search menu item
     private fun setUpSearchMenuItem(menu: Menu) {
         val searchManager: SearchManager =
-            (getSystemService(Context.SEARCH_SERVICE)) as SearchManager
+                (getSystemService(Context.SEARCH_SERVICE)) as SearchManager
         val searchView: SearchView = ((menu.findItem(R.id.action_search)?.actionView)) as SearchView
         val searchMenuItem: MenuItem = menu.findItem(R.id.action_search)
 
@@ -211,11 +213,21 @@ class MainActivity : AppCompatActivity(), SwipeRefreshLayout.OnRefreshListener {
 
     //Retrofit Builder and generator.
     private fun generateRetrofitBuilder(): Retrofit {
+
+        val cacheSize: Long = 10 * 1024 * 1024 // 10 MB
+
+        val cache = Cache(cacheDir, cacheSize)
+
+        val okHttpClient = OkHttpClient.Builder()
+                .cache(cache)
+                .build()
+
         return Retrofit.Builder()
-            .baseUrl(ENDPOINT_URL)
-            .addConverterFactory(GsonConverterFactory.create())
-            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-            .build()
+                .baseUrl(ENDPOINT_URL)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build()
     }
 }
 

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Thu Aug 15 10:46:48 BST 2019
-sdk.dir=/Users/android/Library/Android/sdk
+#Fri Jul 03 19:12:17 IST 2020
+sdk.dir=C\:\\Users\\Chhatrapati\\AppData\\Local\\Android\\Sdk

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Jul 03 19:12:17 IST 2020
-sdk.dir=C\:\\Users\\Chhatrapati\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Enabled retrofit caching to preserve the API response in the offline model and deleted local.properties since it is not needed to be in VCS.